### PR TITLE
No reporters by default

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,7 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-config :setup, :home, '/dev/null'
+config :setup, :home, '/tmp'
 
 config :exometer, :predefined, [
   {[:erlang, :system_info], {:function, :erlang, :system_info, [:'$dp'], :value, [:port_count, :process_count, :thread_pool_size]}, []},

--- a/config/config.exs
+++ b/config/config.exs
@@ -11,9 +11,6 @@ config :exometer, :predefined, [
 ]
 
 config :exometer, :report,
-  reporters: [
-    {:exometer_report_graphite, [{:host, 'localhost'}, {:port, 2003}, {:api_key, 'exometer'}]}
-  ],
   subscribers: [
     {:exometer_report_graphite, [:erlang, :system_info], :port_count, 1000, true},
     {:exometer_report_graphite, [:erlang, :system_info], :process_count, 1000, true},

--- a/test/metricman_test.exs
+++ b/test/metricman_test.exs
@@ -14,7 +14,7 @@ defmodule MetricmanTest do
     assert length(:exometer_report.list_subscriptions(:exometer_report_graphite)) > 0
   end
 
-  test "home dir to /dev/null" do
-    assert '/dev/null' == Application.get_env(:setup, :home)
+  test "home dir to /tmp" do
+    assert '/tmp' == Application.get_env(:setup, :home)
   end
 end

--- a/test/metricman_test.exs
+++ b/test/metricman_test.exs
@@ -2,7 +2,7 @@ defmodule MetricmanTest do
   use ExUnit.Case
 
   test "list reporters" do
-    assert length(:exometer_report.list_reporters) == 1
+    assert length(:exometer_report.list_reporters) == 0
   end
 
   test "list metrics" do


### PR DESCRIPTION
If you want to use exometer reporters you have to add something like this to your config:

``` elixir
config :exometer, :report,
  reporters: [
    {:exometer_report_graphite, [{:host, 'localhost'}, {:port, 2003}, {:api_key, 'exometer'}]}
  ]
```
