### PR TITLE
Turn on tty reporter

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -32,9 +32,7 @@ config :metricman, :subscriptions, [
     {[:erlang, :memory], :atom_used, 2000}
   ]
 
-# HOTFIX: temporary turn tty reporter off
-# because there are some issues with conform.effective in test env
-#if Mix.env == :test do
-  #config :exometer, :report, 
-    #reporters:  [{:exometer_report_tty, []}]
-#end
+if Mix.env == :test do
+  config :exometer, :report,
+    reporters:  [{:exometer_report_tty, []}]
+end

--- a/test/metricman_test.exs
+++ b/test/metricman_test.exs
@@ -2,8 +2,7 @@ defmodule MetricmanTest do
   use ExUnit.Case
 
   test "list reporters" do
-    #assert length(:exometer_report.list_reporters) == 1
-    assert length(:exometer_report.list_reporters) == 0
+    assert length(:exometer_report.list_reporters) == 1
   end
 
   test "list metrics" do
@@ -12,7 +11,7 @@ defmodule MetricmanTest do
   end
 
   test "list subscriptions" do
-    #assert length(:exometer_report.list_subscriptions(:exometer_report_tty)) > 0
+    assert length(:exometer_report.list_subscriptions(:exometer_report_tty)) > 0
   end
 
   test "verify_directories false" do


### PR DESCRIPTION
We turned off exometer tty reporter in the previous commit (5fbfabdb),
now bug in conform is fixed and we can turn on it again.
