### PR TITLE
Add dummy reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: elixir
 otp_release:
-    - 17.4
-before_script:
-    "nc -l 2003 &"
+    - 17.5
+    - 18.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: elixir
+sudo: false
+elixir:
+  - 1.1.0
+  - 1.2.0
 otp_release:
     - 17.5
-    - 18.9
+    - 18.0

--- a/config/config.exs
+++ b/config/config.exs
@@ -34,5 +34,5 @@ config :metricman, :subscriptions, [
 
 if Mix.env == :test do
   config :exometer_core, :report,
-    reporters:  [{:exometer_report_tty, []}]
+    reporters:  [{Metricman.DummyReporter, []}]
 end

--- a/lib/metricman_dummy_report.ex
+++ b/lib/metricman_dummy_report.ex
@@ -1,0 +1,12 @@
+defmodule Metricman.DummyReporter do
+  def exometer_init(_opts), do: {:ok, []}
+  def exometer_subscribe(_metric, _datapoint, _extra, _interval, st), do: {:ok, st}
+  def exometer_unsubscribe(_metric, _dataPoint, _extra, st), do: {:ok, st}
+  def exometer_report(_metric, _datapoint, _extra, _value, st), do: {:ok, st}
+  def exometer_call(_unknown, _from, st), do: {:ok, st}
+  def exometer_cast(_unknown, st), do: {:ok, st}
+  def exometer_info(_unknown, st), do: {:ok, st}
+  def exometer_newentry(_entry, st), do: {:ok, st}
+  def exometer_setopts(_metric, _options, _status, st), do: {:ok, st}
+  def exometer_terminate(_, _), do: :ignore
+end

--- a/test/metricman_test.exs
+++ b/test/metricman_test.exs
@@ -11,7 +11,7 @@ defmodule MetricmanTest do
   end
 
   test "list subscriptions" do
-    assert length(:exometer_report.list_subscriptions(:exometer_report_tty)) > 0
+    assert length(:exometer_report.list_subscriptions(Metricman.DummyReporter)) > 0
   end
 
   test "verify_directories false" do


### PR DESCRIPTION
We need have some reporters for testing how subscriptions work but tty reporter makes a lot noise.
This commit adds dummy reporter which can be used for making subscriptions without any noise.
