### PR TITLE
Add several metrics

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,10 @@ config :exometer_core, :predefined, [
   {[:erlang, :statistics], {:function, :erlang, :statistics, [:'$dp'], :value, [:run_queue]}, []},
   {[:erlang, :statistics, :garbage_collection], {:function, Metricman, :garbage_collection, [], :value, [:number_of_gcs, :words_reclaimed]}, []},
   {[:erlang, :statistics, :io], {:function, Metricman, :io, [], :value, [:input, :output]}, []},
-  {[:erlang, :memory], {:function, :erlang, :memory, [:'$dp'], :value, [:total, :processes, :processes_used, :system, :ets, :binary, :code, :atom, :atom_used]}, []}
+  {[:erlang, :memory], {:function, :erlang, :memory, [:'$dp'], :value, [:total, :processes, :processes_used, :system, :ets, :binary, :code, :atom, :atom_used]}, []},
+  {[:erlang, :scheduler, :usage], {:function, :recon, :scheduler_usage, [1000], :proplist, :lists.seq(1, :erlang.system_info(:schedulers))}, []},
+  {[:erlang, :beam, :start_time], :gauge, []},
+  {[:erlang, :beam, :uptime], {:function, Metricman, :update_uptime, [], :proplist, [:value]}, []}
 ]
 
 config :metricman, :subscriptions, [
@@ -29,7 +32,10 @@ config :metricman, :subscriptions, [
     {[:erlang, :memory], :binary, 2000},
     {[:erlang, :memory], :code, 2000},
     {[:erlang, :memory], :atom, 2000},
-    {[:erlang, :memory], :atom_used, 2000}
+    {[:erlang, :memory], :atom_used, 2000},
+    {[:erlang, :scheduler, :usage], :lists.seq(1, :erlang.system_info(:schedulers)), 2000},
+    {[:erlang, :beam, :start_time], :value, 2000},
+    {[:erlang, :beam, :uptime], :value, 2000}
   ]
 
 if Mix.env == :test do

--- a/lib/metricman.ex
+++ b/lib/metricman.ex
@@ -8,6 +8,7 @@ defmodule Metricman do
     children = []
 
     subscribe_all
+    :exometer.update([:erlang, :beam, :start_time], timestamp())
 
     opts = [strategy: :one_for_one]
     Supervisor.start_link(children, opts)
@@ -30,4 +31,21 @@ defmodule Metricman do
       end
     end
   end
+
+  def update_uptime do
+    {:ok, [{:value, start_time}, _ ]} = :exometer.get_value([:erlang, :beam, :start_time])
+    uptime = timestamp() - start_time
+    [value: round(uptime)]
+  end
+
+  def timestamp() do
+    try do
+      :erlang.system_time(:milli_seconds)
+    rescue # fallback for erlang 17 and older
+      _error ->
+        {mega_secs, secs, micro_secs} = :os.timestamp()
+        1000 * (secs + (mega_secs * 1000000) + (micro_secs / 10000000))
+    end
+  end
+
 end

--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,7 @@ defmodule Metricman.Mixfile do
 
      {:exometer_influxdb, github: "travelping/exometer_influxdb", branch: "master"},
 
+     {:recon, "~> 2.2.1"},
      {:goldrush, github: "DeadZen/goldrush", tag: "0.1.6", override: true},
      {:setup, github: "uwiger/setup", branch: "master", override: true},
      {:edown, github: "uwiger/edown", branch: "master", override: true}


### PR DESCRIPTION
- Scheduler usage, e.g. per scheduler a number between 0 and 1
  will be generated which shows the exhaustion of each scheduler
  
  Further infos from the recon docu:
  
  "For any time interval, Scheduler wall time can be used as a measure
  of how 'busy' a scheduler is. A scheduler is busy when:
  - executing process code
  - executing driver code
  - executing NIF code
  - executing BIFs
  - garbage collecting
  - doing memory management
  
  A scheduler isn't busy when doing anything else."
- Start time of the metricman application to get an approximate value
  for the start time of the BEAM.
- Uptime of metricman to get an approximate value for the uptime of
  the BEAM.

Every time measurement is in ms.
