### PR TITLE
Remove subscription mechanisms

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ It is just meta package which depends on [Feuerlabs/exometer_core](https://githu
     memory       atom_used
     memory       maximum
 
+You can see the created metrics in `config/config.exs`. Note that the metrics are only created. If you want to expose them via a reporter then you need to subscribe to them within your application.
+
 ## Dependencies tree
 
     xerions/metricman 

--- a/config/config.exs
+++ b/config/config.exs
@@ -15,29 +15,6 @@ config :exometer_core, :predefined, [
   {[:erlang, :beam, :uptime], {:function, Metricman, :update_uptime, [], :proplist, [:value]}, []}
 ]
 
-config :metricman, :subscriptions, [
-    {[:erlang, :system_info], :port_count, 2000},
-    {[:erlang, :system_info], :process_count, 2000},
-    {[:erlang, :system_info], :thread_pool_size, 2000},
-    {[:erlang, :statistics], :run_queue, 2000},
-    {[:erlang, :statistics, :garbage_collection], :number_of_gcs, 2000},
-    {[:erlang, :statistics, :garbage_collection], :words_reclaimed, 2000},
-    {[:erlang, :statistics, :io], :input, 2000},
-    {[:erlang, :statistics, :io], :output, 2000},
-    {[:erlang, :memory], :total, 2000},
-    {[:erlang, :memory], :processes, 2000},
-    {[:erlang, :memory], :processes_used, 2000},
-    {[:erlang, :memory], :system, 2000},
-    {[:erlang, :memory], :ets, 2000},
-    {[:erlang, :memory], :binary, 2000},
-    {[:erlang, :memory], :code, 2000},
-    {[:erlang, :memory], :atom, 2000},
-    {[:erlang, :memory], :atom_used, 2000},
-    {[:erlang, :scheduler, :usage], :lists.seq(1, :erlang.system_info(:schedulers)), 2000},
-    {[:erlang, :beam, :start_time], :value, 2000},
-    {[:erlang, :beam, :uptime], :value, 2000}
-  ]
-
 if Mix.env == :test do
   config :exometer_core, :report,
     reporters:  [{Metricman.DummyReporter, []}]

--- a/lib/metricman.ex
+++ b/lib/metricman.ex
@@ -7,7 +7,6 @@ defmodule Metricman do
 
     children = []
 
-    subscribe_all
     :exometer.update([:erlang, :beam, :start_time], timestamp())
 
     opts = [strategy: :one_for_one]
@@ -22,14 +21,6 @@ defmodule Metricman do
   def io do
     {{:input, input}, {:output, output}} = :erlang.statistics(:io)
     [input: input, output: output]
-  end
-
-  def subscribe_all do
-    for {reporter, _} <- :exometer_report.list_reporters do
-      for {name, data_point, time} <- Application.get_env(:metricman, :subscriptions) do
-        :exometer_report.subscribe(reporter, name, data_point, time)
-      end
-    end
   end
 
   def update_uptime do

--- a/test/metricman_test.exs
+++ b/test/metricman_test.exs
@@ -11,7 +11,10 @@ defmodule MetricmanTest do
   end
 
   test "list subscriptions" do
+    assert :ok = :exometer_report.subscribe(Metricman.DummyReporter, [:erlang, :memory], :total, 100)
     assert length(:exometer_report.list_subscriptions(Metricman.DummyReporter)) > 0
+    assert :ok = :exometer_report.unsubscribe_all(Metricman.DummyReporter, [:erlang, :memory])
+    assert length(:exometer_report.list_subscriptions(Metricman.DummyReporter)) == 0
   end
 
   test "verify_directories false" do


### PR DESCRIPTION
Metrics are not subscribed automatically anymore when a reporter is set in the env variables.

Metrics not need to be subscribed from within the application which has metricman as dependency.
