### PR TITLE
semantic restructuring of metrics/datapoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,16 @@
 # Metricman [![Build Status](https://travis-ci.org/xerions/metricman.svg?branch=master)](https://travis-ci.org/xerions/metricman)
 
-It is just meta package which depends on [Feuerlabs/exometer_core](https://github.com/xerions/exometer), [travelping/exometer_influxdb](https://github.com/travelping/exometer_influxdb) and configures some VM metrics like this:
+It is just meta package which depends on [Feuerlabs/exometer_core](https://github.com/xerions/exometer), [travelping/exometer_influxdb](https://github.com/travelping/exometer_influxdb) and configures some VM metrics:
 
-    system_info  port_count
-    system_info  process_count
-    system_info  thread_pool_size
-    statistics   run_queue
-    statistics   garbage_collection
-    statistics   io
-    memory       total
-    memory       processes
-    memory       ets
-    memory       binary
-    memory       atom
-    memory       atom_used
-    memory       maximum
-    scheduler    usage
-    beam         start time
-    beam         uptime
+  * Erlang release version number
+  * BEAM start and uptime
+  * Port information
+  * Processes information
+  * Processors information
+  * Garabage collection
+  * I/O
+  * Memory usage
+  * Scheduler usage
 
 You can see the created metrics in `config/config.exs`. Note that the metrics are only created. If you want to expose them via a reporter then you need to subscribe to them from within your application.
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,12 +5,14 @@ use Mix.Config
 config :setup, :verify_directories, false
 
 config :exometer_core, :predefined, [
-  {[:erlang, :system_info], {:function, :erlang, :system_info, [:'$dp'], :value, [:port_count, :process_count, :thread_pool_size]}, []},
-  {[:erlang, :statistics], {:function, :erlang, :statistics, [:'$dp'], :value, [:run_queue]}, []},
-  {[:erlang, :statistics, :garbage_collection], {:function, Metricman, :garbage_collection, [], :value, [:number_of_gcs, :words_reclaimed]}, []},
-  {[:erlang, :statistics, :io], {:function, Metricman, :io, [], :value, [:input, :output]}, []},
-  {[:erlang, :memory], {:function, :erlang, :memory, [:'$dp'], :value, [:total, :processes, :processes_used, :system, :ets, :binary, :code, :atom, :atom_used]}, []},
-  {[:erlang, :scheduler, :usage], {:function, :recon, :scheduler_usage, [1000], :proplist, :lists.seq(1, :erlang.system_info(:schedulers))}, []},
+  {[:erlang, :otp_release], {:function, :erlang, :system_info, [:'$dp'], :value, [:otp_release]}, []},
+  {[:erlang, :beam, :port],    {:function, :erlang, :system_info, [:'$dp'], :value, [:port_count, :port_limit]}, []},
+  {[:erlang, :beam, :process], {:function, Metricman, :process_info, [], :proplist, [:process_count, :process_limit, :run_queue_size]}, []},
+  {[:erlang, :beam, :processor], {:function, :erlang, :system_info, [:'$dp'], :value, [:logical_processors, :logical_processors_available, :logical_processors_online]}, []},
+  {[:erlang, :beam, :garbage_collection], {:function, Metricman, :garbage_collection, [], :value, [:number_of_gcs, :words_reclaimed]}, []},
+  {[:erlang, :beam, :io], {:function, Metricman, :io, [], :value, [:input, :output]}, []},
+  {[:erlang, :beam, :memory], {:function, :erlang, :memory, [:'$dp'], :value, [:total, :processes, :processes_used, :system, :ets, :binary, :code, :atom, :atom_used]}, []},
+  {[:erlang, :beam, :scheduler_usage], {:function, :recon, :scheduler_usage, [1000], :proplist, :lists.seq(1, :erlang.system_info(:schedulers))}, []},
   {[:erlang, :beam, :start_time], :gauge, []},
   {[:erlang, :beam, :uptime], {:function, Metricman, :update_uptime, [], :proplist, [:value]}, []}
 ]

--- a/lib/metricman.ex
+++ b/lib/metricman.ex
@@ -23,6 +23,13 @@ defmodule Metricman do
     [input: input, output: output]
   end
 
+  def process_info do
+    process_count = :erlang.system_info(:process_count)
+    process_limit = :erlang.system_info(:process_limit)
+    run_queue_size = :erlang.statistics(:run_queue)
+    [process_count: process_count, process_limit: process_limit, run_queue_size: run_queue_size]
+  end
+
   def update_uptime do
     {:ok, [{:value, start_time}, _ ]} = :exometer.get_value([:erlang, :beam, :start_time])
     uptime = timestamp() - start_time

--- a/test/metricman_test.exs
+++ b/test/metricman_test.exs
@@ -11,9 +11,9 @@ defmodule MetricmanTest do
   end
 
   test "list subscriptions" do
-    assert :ok = :exometer_report.subscribe(Metricman.DummyReporter, [:erlang, :memory], :total, 100)
+    assert :ok = :exometer_report.subscribe(Metricman.DummyReporter, [:erlang, :beam, :memory], :total, 100)
     assert length(:exometer_report.list_subscriptions(Metricman.DummyReporter)) > 0
-    assert :ok = :exometer_report.unsubscribe_all(Metricman.DummyReporter, [:erlang, :memory])
+    assert :ok = :exometer_report.unsubscribe_all(Metricman.DummyReporter, [:erlang, :beam, :memory])
     assert length(:exometer_report.list_subscriptions(Metricman.DummyReporter)) == 0
   end
 


### PR DESCRIPTION
After reading about erlang:system_info/1 I decided for some further changes:
- restructured exometer ids
- add otp version number metric
- add processors metric
- remove I/O function call from Metricman module
- add datapoints for process and port limits
- update README
