### PR TITLE
Fix names clashing issue

### DIFF
--- a/lib/subscription.ex
+++ b/lib/subscription.ex
@@ -97,8 +97,8 @@ defmodule Metricman.Subscription do
                                      ("$" <> id, ids) -> ids ++ [{id |> to_downcased_atom, [], Elixir}]
                                      (id, ids) -> ids ++ [id] end)
     vars = List.foldl(exo_id, [], 
-                      fn ([?$ | id], acc) -> acc ++ [id |> to_downcased_atom]
-                         ("$" <>  id, acc) -> acc ++ [id |> to_downcased_atom]
+                      fn ([?$ | _] = id, acc) -> acc ++ [id |> to_downcased_atom]
+                         ("$" <>  _ = id, acc) -> acc ++ [id |> to_downcased_atom]
                          (_, acc) ->  acc ++ [:_]
                       end)
     quote do 
@@ -107,8 +107,8 @@ defmodule Metricman.Subscription do
                |> Enum.zip(unquote(exo_id_for_match)) 
                |> Enum.filter(fn({x, _}) -> x != :_ end)
         path = List.foldl(@path ++ unquote(id), [], 
-                          fn ([?$ | id], acc) -> acc ++ [id |> to_downcased_atom]
-                             ("$" <> id, acc) -> acc ++ [id |> to_downcased_atom]
+                          fn ([?$ | _] = id, acc) -> acc ++ [id |> to_downcased_atom]
+                             ("$" <> _ = id, acc) -> acc ++ [id |> to_downcased_atom]
                              (id, acc) ->  acc ++ [id]
                           end)
         opts = Keyword.merge(@opts, unquote(opts))

--- a/test/subscription_test.exs
+++ b/test/subscription_test.exs
@@ -13,10 +13,10 @@ defmodule MetricmanSubscribtionTest do
       map [:used],  [:ippools, :ip, :total, :used]
       map [:total], [:ippools, :ip, :total, :total], @opts2
       scope ['$country'] do
-        scope [:region, "$city"] do # it is posible to use list and string as variable name
-          map [:used],  [:ippools, :ip, '$country', '$city', :used]
-          map [:total], [:ippools, :ip, "$country", "$city", :total]
-          map [:func], [:ippools, :ip, "$country", "$city", :func]
+        scope [:region, "$region"] do # it is posible to use list and string as variable name
+          map [:used],  [:ippools, :ip, '$country', '$region', :used]
+          map [:total], [:ippools, :ip, "$country", "$region", :total]
+          map [:func], [:ippools, :ip, "$country", "$region", :func]
         end
         map [:used],  [:ippools, :ip, '$country', :used]
         map [:total], [:ippools, :ip, '$country', :total]


### PR DESCRIPTION
There was names clashing issue when we use variables with the same name
that exometer id already has.

See #23
