### PR TITLE
Remove recon:scheduler_usage from predefined metrics

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -12,7 +12,7 @@ config :exometer_core, :predefined, [
   {[:erlang, :beam, :garbage_collection], {:function, Metricman, :garbage_collection, [], :value, [:number_of_gcs, :words_reclaimed]}, []},
   {[:erlang, :beam, :io], {:function, Metricman, :io, [], :value, [:input, :output]}, []},
   {[:erlang, :beam, :memory], {:function, :erlang, :memory, [:'$dp'], :value, [:total, :processes, :processes_used, :system, :ets, :binary, :code, :atom, :atom_used]}, []},
-  {[:erlang, :beam, :scheduler_usage], {:function, :recon, :scheduler_usage, [1000], :proplist, :lists.seq(1, :erlang.system_info(:schedulers))}, []},
+  #{[:erlang, :beam, :scheduler_usage], {:function, :recon, :scheduler_usage, [1000], :proplist, :lists.seq(1, :erlang.system_info(:schedulers))}, []},
   {[:erlang, :beam, :start_time], :gauge, []},
   {[:erlang, :beam, :uptime], {:function, Metricman, :update_uptime, [], :proplist, [:value]}, []}
 ]


### PR DESCRIPTION
Because it is blocking calling process for 1s.